### PR TITLE
Fix SSRF vulnerability and add localhost allowlist mechanism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,7 @@
 
     "DB_PASSWORD": "",
 
-    "DB_NAME": "localgoogoo"
+    "DB_NAME": "localgoogoo",
+
+    "ALLOWED_LOCALHOST_PATTERNS": ["*"]
 }

--- a/php/crawler/crawler.class.php
+++ b/php/crawler/crawler.class.php
@@ -619,6 +619,10 @@ sql;
      */
     private function getPageContent($url)
     {
+        if (!isValidUrl($url)) {
+            return false;
+        }
+
         if (array_key_exists($url, $this->pageContentCache)) {
             return $this->pageContentCache[$url];
         }

--- a/php/inc/helpers.inc.php
+++ b/php/inc/helpers.inc.php
@@ -73,6 +73,63 @@ function _link($name, $start, $isCurrent=false)
 
 /* crawl.php, start_crawler.php */
 
+function isValidUrl($url)
+{
+    $parsed = parse_url($url);
+    if (!$parsed || !isset($parsed['scheme'])) {
+        return false;
+    }
+
+    $scheme = strtolower($parsed['scheme']);
+    if (!in_array($scheme, ['http', 'https'])) {
+        return false;
+    }
+
+    $host = $parsed['host'] ?? '';
+
+    // Check if localhost
+    $isLocal = false;
+    if (strtolower($host) === 'localhost') {
+        $isLocal = true;
+    } else {
+        $ip = gethostbyname($host);
+        // If it's a valid IP
+        if (filter_var($ip, FILTER_VALIDATE_IP)) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                if (strpos($ip, '127.') === 0) {
+                    $isLocal = true;
+                }
+            } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                if ($ip === '::1') {
+                    $isLocal = true;
+                }
+            }
+        }
+    }
+
+    if ($isLocal) {
+        $configPath = __DIR__ . '/../../config.json';
+        if (file_exists($configPath)) {
+            $config = json_decode(file_get_contents($configPath), true);
+            $allowed = $config['ALLOWED_LOCALHOST_PATTERNS'] ?? [];
+
+            if (in_array('*', $allowed)) {
+                return true;
+            }
+
+            foreach ($allowed as $pattern) {
+                if (fnmatch($pattern, $url)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return false;
+    }
+
+    return true;
+}
+
 function getPageContent($url)
 {
     return ($cnt = @file_get_contents($url)) ? $cnt : 0;
@@ -82,6 +139,7 @@ function getPageContent($url)
 function isInvalid($name, $url)
 {
     return empty($name) || empty($url)
+        || !isValidUrl($url)
         || !getPageContent($url);
 }
 
@@ -140,7 +198,8 @@ function prepareConfigFile($config_file)
             'DB_HOST' => 'localhost',
             'DB_USER' => 'root',
             'DB_PASSWORD' => '',
-            'DB_NAME' => 'localgoogoo'
+            'DB_NAME' => 'localgoogoo',
+            'ALLOWED_LOCALHOST_PATTERNS' => ['*']
         ];
     
         file_put_contents($config_file, json_encode($data, JSON_PRETTY_PRINT));


### PR DESCRIPTION
This change addresses the SSRF vulnerability where arbitrary protocols (like `file://`) and unchecked localhost ports could be accessed.

Changes:
1.  **`php/inc/helpers.inc.php`**: Added `isValidUrl` function. This function checks:
    *   The URL scheme is strictly `http` or `https`.
    *   If the host resolves to a local IP address (127.0.0.0/8, ::1) or is `localhost`, it checks against `ALLOWED_LOCALHOST_PATTERNS` in `config.json`.
2.  **`php/crawler/crawler.class.php`**: Updated `getPageContent` to verify URLs using `isValidUrl` before fetching content.
3.  **`config.json`**: Added `ALLOWED_LOCALHOST_PATTERNS` key defaulting to `["*"]` (allow all), as per user requirements to keep localhost accessible by default but configurable.

Tests performed:
- Verified `file://` URLs are blocked.
- Verified `http://localhost:8081` is allowed by default.
- Verified `http://localhost:8081` is blocked if `config.json` allowlist is empty or mismatching.
- Verified external URLs (e.g. `http://example.com`) are allowed.

---
*PR created automatically by Jules for task [14477017370566047588](https://jules.google.com/task/14477017370566047588) started by @kodejuice*