### PR TITLE
Add PDF indexing support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.3",
         "ext-mysqli": "*",
-        "league/climate": "^3.2"
+        "league/climate": "^3.10",
+        "smalot/pdfparser": "^2.12"
     },
     "bin": ["bin/localgoogoo"],
     "version": "1.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,195 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a1c182c23b7008a26d09d2f9a2e943e",
+    "content-hash": "136d269410fa035842df3dc8cce45c51",
     "packages": [
         {
-            "name": "elasticsearch/elasticsearch",
-            "version": "v7.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "1d90a7ff4fb1936dc4376f09d723af75714f6f05"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/1d90a7ff4fb1936dc4376f09d723af75714f6f05",
-                "reference": "1d90a7ff4fb1936dc4376f09d723af75714f6f05",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": ">=1.3.7",
-                "ezimuel/ringphp": "^1.1.2",
-                "php": "^7.1",
-                "psr/log": "~1.0"
-            },
-            "require-dev": {
-                "cpliakas/git-wrapper": "~2.0",
-                "doctrine/inflector": "^1.3",
-                "mockery/mockery": "^1.2",
-                "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5",
-                "squizlabs/php_codesniffer": "^3.4",
-                "symfony/finder": "~4.0",
-                "symfony/yaml": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "*",
-                "monolog/monolog": "Allows for client-level logging and tracing"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Elasticsearch\\": "src/Elasticsearch/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Zachary Tong"
-                },
-                {
-                    "name": "Enrico Zimuel"
-                }
-            ],
-            "description": "PHP Client for Elasticsearch",
-            "keywords": [
-                "client",
-                "elasticsearch",
-                "search"
-            ],
-            "time": "2020-05-13T15:19:26+00:00"
-        },
-        {
-            "name": "ezimuel/guzzlestreams",
-            "version": "3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezimuel/guzzlestreams.git",
-                "reference": "abe3791d231167f14eb80d413420d1eab91163a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezimuel/guzzlestreams/zipball/abe3791d231167f14eb80d413420d1eab91163a8",
-                "reference": "abe3791d231167f14eb80d413420d1eab91163a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Fork of guzzle/streams (abandoned) to be used with elasticsearch-php",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "time": "2020-02-14T23:11:50+00:00"
-        },
-        {
-            "name": "ezimuel/ringphp",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezimuel/ringphp.git",
-                "reference": "0b78f89d8e0bb9e380046c31adfa40347e9f663b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezimuel/ringphp/zipball/0b78f89d8e0bb9e380046c31adfa40347e9f663b",
-                "reference": "0b78f89d8e0bb9e380046c31adfa40347e9f663b",
-                "shasum": ""
-            },
-            "require": {
-                "ezimuel/guzzlestreams": "^3.0.1",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Fork of guzzle/RingPHP (abandoned) to be used with elasticsearch-php",
-            "time": "2020-02-14T23:51:21+00:00"
-        },
-        {
             "name": "league/climate",
-            "version": "3.5.2",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/climate.git",
-                "reference": "6b53a28a58ad9f5f63042e291eb870cf0d02a9c9"
+                "reference": "237f70e1032b16d32ff3f65dcda68706911e1c74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/climate/zipball/6b53a28a58ad9f5f63042e291eb870cf0d02a9c9",
-                "reference": "6b53a28a58ad9f5f63042e291eb870cf0d02a9c9",
+                "url": "https://api.github.com/repos/thephpleague/climate/zipball/237f70e1032b16d32ff3f65dcda68706911e1c74",
+                "reference": "237f70e1032b16d32ff3f65dcda68706911e1c74",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "psr/log": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "seld/cli-prompt": "^1.0"
             },
             "require-dev": {
-                "mikey179/vfsstream": "^1.4",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^5.7.16"
+                "mikey179/vfsstream": "^1.6.12",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^9.5.10",
+                "squizlabs/php_codesniffer": "^3.10"
             },
             "suggest": {
                 "ext-mbstring": "If ext-mbstring is not available you MUST install symfony/polyfill-mbstring"
@@ -229,84 +66,11 @@
                 "php",
                 "terminal"
             ],
-            "time": "2019-12-01T15:25:43+00:00"
-        },
-        {
-            "name": "monolog/monolog",
-            "version": "1.25.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "3022efff205e2448b560c833c6fbbf91c3139168"
+            "support": {
+                "issues": "https://github.com/thephpleague/climate/issues",
+                "source": "https://github.com/thephpleague/climate/tree/3.10.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3022efff205e2448b560c833c6fbbf91c3139168",
-                "reference": "3022efff205e2448b560c833c6fbbf91c3139168",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "php-amqplib/php-amqplib": "~2.4",
-                "php-console/php-console": "^3.1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
-                "phpunit/phpunit": "~4.5",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
-                "swiftmailer/swiftmailer": "^5.3|^6.0"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "time": "2020-05-22T07:31:27+00:00"
+            "time": "2024-11-18T09:09:55+00:00"
         },
         {
             "name": "psr/log",
@@ -356,52 +120,6 @@
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
-            "name": "react/promise",
-            "version": "v2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "time": "2020-05-12T15:16:56+00:00"
-        },
-        {
             "name": "seld/cli-prompt",
             "version": "1.0.3",
             "source": {
@@ -448,17 +166,154 @@
                 "prompt"
             ],
             "time": "2017-03-18T11:32:45+00:00"
+        },
+        {
+            "name": "smalot/pdfparser",
+            "version": "v2.12.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "61c9bcafcb92899b76d8ebda6508267bae77e264"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/61c9bcafcb92899b76d8ebda6508267bae77e264",
+                "reference": "61c9bcafcb92899b76d8ebda6508267bae77e264",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.12.3"
+            },
+            "time": "2026-01-08T08:04:04+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.0.0",
         "ext-mysqli": "*"
     },
-    "platform-dev": []
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/config.json
+++ b/config.json
@@ -1,11 +1,11 @@
 {
-    "DB_HOST": "localhost",
-    
-    "DB_USER": "root",
+ "DB_HOST": "localhost",
 
-    "DB_PASSWORD": "",
+ "DB_USER": "root",
 
-    "DB_NAME": "localgoogoo",
+ "DB_PASSWORD": "",
 
-    "ALLOWED_LOCALHOST_PATTERNS": ["*"]
+ "DB_NAME": "localgoogoo",
+
+ "ALLOWED_LOCALHOST_PATTERNS": ["*"]
 }

--- a/php/crawl.php
+++ b/php/crawl.php
@@ -12,6 +12,7 @@ set_time_limit(86400 * 31);
 
 const included = true;
 
+require_once __DIR__ . '/../vendor/autoload.php';
 require_once "inc/helpers.inc.php";
 require_once "inc/setup_database.inc.php";
 require_once "crawler/crawler.class.php";

--- a/php/crawler/crawler.class.php
+++ b/php/crawler/crawler.class.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 require_once __DIR__ . "/../lib/simple_html_dom.php";
 require_once __DIR__ . "/../inc/helpers.inc.php";
 
+use Smalot\PdfParser\Parser;
+
 class LGCrawler
 {
     private $siteurl;
@@ -168,19 +170,32 @@ class LGCrawler
         // remove queries
         extract(parse_url($url));
         $path = isset($path) ? $path : "/";
-        $url = ("$scheme://$host$path");
+        $portStr = isset($port) ? ":$port" : "";
+        $url = ("$scheme://$host$portStr$path");
 
-        // if (url is not 200) or (page isn't html) or (page is already cralwed), { dont crawl }
-        if (!($fileContent = $this->getPageContent($url)) || !$this->isHTML($fileContent) || array_key_exists($url, $crawledPages)) {
+        $fileContent = $this->getPageContent($url);
+        if (!$fileContent) {
+            return;
+        }
+
+        $isPdf = $this->isPDF($fileContent);
+
+        // if (url is not 200) or (page isn't html AND isn't pdf) or (page is already cralwed), { dont crawl }
+        if ((!$this->isHTML($fileContent) && !$isPdf) || array_key_exists($url, $crawledPages)) {
             return;
         }
 
         // add current page to database,
         if (!array_key_exists($url, $crawledPages)) {
             if (!array_key_exists($url, $this->crawledPagesInDB)) {
-                $this->addPageToDatabase($url, $fileContent);
+                $this->addPageToDatabase($url, $fileContent, $isPdf);
             }
             $crawledPages[$url] = 1;
+        }
+
+        // if it is a PDF, we don't extract links
+        if ($isPdf) {
+            return;
         }
 
         // will hold all links in the the current page
@@ -200,7 +215,8 @@ class LGCrawler
                 // remove queries from url
                 extract(parse_url($pageURL));
                 $path = isset($path) ? $path : "/";
-                $pageURL = ("$scheme://$host$path");
+                $portStr = isset($port) ? ":$port" : "";
+                $pageURL = ("$scheme://$host$portStr$path");
 
                 if ($this->isAlike($this->siteurl, $pageURL) && !array_key_exists($pageURL, $crawledPages)) {
                     array_push($links, $pageURL);
@@ -332,48 +348,70 @@ class LGCrawler
      *
      * @param [string] $link    page url
      * @param [string] $content page content
+     * @param [boolean] $isPdf  is it a pdf file
      *
      * @return [boolean]        page added or not
      */
-    private function addPageToDatabase($link, $content)
+    private function addPageToDatabase($link, $content, $isPdf = false)
     {
         $name = $this->sitename;
         $conn = $this->SQLConn;
 
-        $dom = str_get_html($content);
+        if ($isPdf) {
+            try {
+                $parser = new Parser();
+                $pdf = $parser->parseContent($content);
+                $text = $pdf->getText();
 
-        // check if the html object has the 'find' method,
-        // if it doesn't (false was returned) then the html content couldn't be parsed (too large)
-        // see the 'lib/simple_html_dom.php' script line 113
-        if (!is_callable([$dom, "find"], true)) {
-            $this->tooLarge = true;
-            return;
+                // Use filename as title for PDF
+                $path = parse_url($link, PHP_URL_PATH);
+                $pageTitle = basename($path);
+
+                $pageEmphasis = "";
+                $pageHeaders = "";
+                $content = $conn->escape_string($this->_trim($text));
+                $pageTitle = $conn->escape_string($pageTitle);
+                $link = $conn->escape_string($link);
+            } catch (\Exception $e) {
+                $this->log($this->logFile, "- Error parsing PDF $link: " . $e->getMessage());
+                return false;
+            }
+        } else {
+            $dom = str_get_html($content);
+
+            // check if the html object has the 'find' method,
+            // if it doesn't (false was returned) then the html content couldn't be parsed (too large)
+            // see the 'lib/simple_html_dom.php' script line 113
+            if (!is_callable([$dom, "find"], true)) {
+                $this->tooLarge = true;
+                return;
+            }
+
+            $pageTitle = isset($dom->find("title")[0]) ? $dom->find("title")[0]->innertext() : "";
+            $pageTitle = $conn->escape_string($pageTitle);
+
+            // get <body> tag from page content
+            $content = isset($dom->find("body")[0])
+                ?  $dom->find("body")[0]->innertext()
+                : $content;
+
+            // escape strings
+            $content = $conn->escape_string($this->_trim($content));
+            $link = $conn->escape_string($link);
+
+            // get dom instance here, so following methods
+            // dont need to call it again
+            $dom = str_get_html($content);
+
+            // get <strong>, <b>, <em> tags from page
+            $pageEmphasis = $this->getPageElems($dom, $content, "strong,em,b");
+
+            // get headers <h1>-<h6>
+            $pageHeaders = $this->getPageElems($dom, $content, "h1,h2,h3,h4,h5,h6");
+
+            // strip out tags and remove useless html elements
+            $content = $this->stripTags($content);
         }
-
-        $pageTitle = isset($dom->find("title")[0]) ? $dom->find("title")[0]->innertext() : "";
-        $pageTitle = $conn->escape_string($pageTitle);
-
-        // get <body> tag from page content
-        $content = isset($dom->find("body")[0])
-            ?  $dom->find("body")[0]->innertext()
-            : $content;
-
-        // escape strings
-        $content = $conn->escape_string($this->_trim($content));
-        $link = $conn->escape_string($link);
-
-        // get dom instance here, so following methods
-        // dont need to call it again
-        $dom = str_get_html($content);
-
-        // get <strong>, <b>, <em> tags from page
-        $pageEmphasis = $this->getPageElems($dom, $content, "strong,em,b");
-
-        // get headers <h1>-<h6>
-        $pageHeaders = $this->getPageElems($dom, $content, "h1,h2,h3,h4,h5,h6");
-
-        // strip out tags and remove useless html elements
-        $content = $this->stripTags($content);
 
         $sql = <<<sql
         INSERT INTO pages (page_website, page_id, page_url, page_title, page_headers, page_emphasis, page_content)
@@ -575,6 +613,18 @@ sql;
     private function isHTML($string)
     {
         return preg_match("/<html.*/i", $string) && preg_match("/<body.*/i", $string);
+    }
+
+    /**
+     * check if string is pdf
+     *
+     * @param [string] $string string to check
+     *
+     * @return [boolean]         pdf or not
+     */
+    private function isPDF($string)
+    {
+        return strpos($string, '%PDF-') === 0;
     }
 
     /**

--- a/tests/test_pdf_indexing.php
+++ b/tests/test_pdf_indexing.php
@@ -1,0 +1,100 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../php/crawler/crawler.class.php';
+
+// Setup Test Environment
+$testDir = __DIR__ . '/test_server_env';
+if (!is_dir($testDir)) {
+    mkdir($testDir);
+}
+
+// Download minimal PDF
+$pdfUrl = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf";
+$pdfContent = @file_get_contents($pdfUrl);
+if (!$pdfContent) {
+    // Fallback if download fails: use a known valid base64 encoded PDF (small one)
+    $pdfContent = base64_decode("JVBERi0xLjQKJcOkw7zDtsOfCjIgMCBvYmoKPDwvTGVuZ3RoIDMgMCBSL0ZpbHRlci9GbGF0ZURlY29kZT4+CnN0cmVhbQp4nE2NPQvCMBCG9/yK400G0uTj1qVbB8FBEAdb6V+Q5sE/35qA4A3v8dzD814iS+4yxs4G66K04yG+4xR9M2A4jGq8qS26s+Gz+QWWRT96h5x7lM+2bfmcn5/JtChxYw5eH3d1K9c3QnQ9l5tqS6/oK75+yN8L2x9jL1t/ACoCJ0wKZW5kc3RyZWFtCmVuZG9iagozIDAgb2JqCjgwCmVuZG9iago1IDAgb2JqCjw8L1BhcmVudCA0IDAgUi9NZWRpYUJveFswIDAgNTk1LjI4IDg0MS44OV0vVHlwZS9QYWdlL1Jlc291cmNlczw8L1Byb2NTZXRbL1BERi9UZXh0XS9Gb250PDwvRjEgMSAwIFI+Pj4+L0NvbnRlbnRzIDIgMCBSPj4KZW5kb2JqCjEgMCBvYmoKPDwvVHlwZS9Gb250L1N1YnR5cGUvVHlwZTEvQmFzZUZvbnQvSGVsdmV0aWNhPj4KZW5kb2JqCjQgMCBvYmoKPDwvVHlwZS9QYWdlcy9Db3VudCAxL0tpZHNbNSAwIFJdPj4KZW5kb2JqCjYgMCBvYmoKPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDQgMCBSPj4KZW5kb2JqCjcgMCBvYmoKPDwvUHJvZHVjZXIoU2ltcGxlIFBERiAxLjAuMCkvQ3JlYXRpb25EYXRlKEQ6MjAyMTAxMjAxNzU0NTYrMDAnMDAnKS9Nb2REYXRlKEQ6MjAyMTAxMjAxNzU0NTYrMDAnMDAnKT4+CmVuZG9iagp4cmVmCjAgOAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAyNjMgMDAwMDAgbiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwMjQ1IDAwMDAwIG4gCjAwMDAwMDAzNTEgMDAwMDAgbiAKMDAwMDAwMDEwNSAwMDAwMCBuIAowMDAwMDAwNDEwIDAwMDAwIG4gCjAwMDAwMDA0NTkgMDAwMDAgbiAKdHJhaWxlcgo8PC9TaXplIDgvUm9vdCA2IDAgUi9JbmZvIDcgMCBSPj4Kc3RhcnR4cmVmCjU3NQolJUVPRgo=");
+    // This PDF contains "Hello World"
+}
+file_put_contents($testDir . '/sample.pdf', $pdfContent);
+file_put_contents($testDir . '/index.html', '<html><body><a href="sample.pdf">PDF</a></body></html>');
+
+// Start PHP Server
+$port = 8999;
+$host = "127.0.0.1";
+$cmd = sprintf('php -S %s:%d -t %s > /dev/null 2>&1 & echo $!', $host, $port, $testDir);
+$pid = exec($cmd);
+
+// Wait for server to start
+sleep(1);
+
+// Mock DB
+class MockMySQLi {
+    public $connect_error = null;
+    public $error = null;
+    public $inserts = [];
+
+    public function escape_string($str) {
+        return addslashes($str);
+    }
+
+    public function query($sql) {
+        $trimmed = trim($sql);
+        if (stripos($trimmed, "INSERT INTO pages") === 0) {
+            $this->inserts[] = $sql;
+            return true;
+        }
+        if (stripos($trimmed, "SELECT COUNT(*) FROM websites") === 0) return new MockResult([[0]]);
+        if (stripos($trimmed, "SELECT page_url FROM pages") === 0) return new MockResult([]);
+        return true;
+    }
+}
+
+class MockResult {
+    private $data;
+    public function __construct($data) { $this->data = $data; }
+    public function fetch_row() { return array_shift($this->data); }
+}
+
+try {
+    echo "Running Test...\n";
+    $mockDb = new MockMySQLi();
+    $crawler = new LGCrawler("TestSite", "http://$host:$port/index.html", $mockDb);
+
+    $crawler->onComplete(function($t){});
+
+    $crawler->startCrawler(function(){});
+
+    // Verify
+    $pdfFound = false;
+    foreach ($mockDb->inserts as $sql) {
+        if (strpos($sql, "sample.pdf") !== false && (strpos($sql, "Dummy PDF file") !== false || strpos($sql, "Hello World") !== false)) {
+            $pdfFound = true;
+            echo "SUCCESS: Found PDF insert with expected content.\n";
+            break;
+        }
+    }
+
+    if (!$pdfFound) {
+        echo "FAILURE: PDF insert not found.\n";
+        echo "Inserts: " . print_r($mockDb->inserts, true) . "\n";
+        if (file_exists(__DIR__ . "/../log.txt")) {
+            echo "Log content:\n" . file_get_contents(__DIR__ . "/../log.txt") . "\n";
+        }
+        exit(1);
+    }
+
+} catch (Exception $e) {
+    echo "ERROR: " . $e->getMessage() . "\n";
+    exit(1);
+} finally {
+    // Cleanup
+    echo "Cleaning up...\n";
+    if ($pid) exec("kill $pid");
+    array_map('unlink', glob("$testDir/*"));
+    if (is_dir($testDir)) rmdir($testDir);
+    // The crawler logs to relative path ../../log.txt from crawler class
+    // which is root log.txt.
+    if (file_exists(__DIR__ . "/../log.txt")) unlink(__DIR__ . "/../log.txt");
+}


### PR DESCRIPTION
Implemented PDF indexing support using `smalot/pdfparser`. The crawler now detects PDF files, extracts their text content, and indexes them with the filename as the title. Link extraction is skipped for PDFs. Also fixed a bug where port numbers were stripped from URLs and added a test case.

---
*PR created automatically by Jules for task [13309399158557096611](https://jules.google.com/task/13309399158557096611) started by @kodejuice*